### PR TITLE
Support for Linux kernel >= 6.8.0-44

### DIFF
--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
@@ -26,6 +26,7 @@
 #include <linux/string.h>
 #include <linux/acpi.h>
 #include <linux/i2c.h>
+#include <linux/version.h>
 
 #include <drm/drm_atomic.h>
 #include <drm/drm_probe_helper.h>
@@ -560,7 +561,11 @@ void dm_helpers_dp_mst_send_payload_allocation(
 #endif
 
 #if defined(HAVE_DRM_DP_MST_TOPOLOGY_STATE_PAYLOADS)
+#if LINUX_VERSION_CODE <= 395276
 	ret = drm_dp_add_payload_part2(mst_mgr, mst_state->base.state, new_payload);
+#else
+	ret = drm_dp_add_payload_part2(mst_mgr, new_payload);
+#endif
 #else
 	ret = drm_dp_update_payload_part2(mst_mgr);
 #endif


### PR DESCRIPTION
Related #3701 and thanks to @kswit for the reference and @alain-bkr for the solution.

I have guarded the code so it doesn't break older kernel versions.

Checking https://packages.ubuntu.com/noble/all/linux-headers-6.8.0-41/download, particularly the `Makefile` it is not clear what the version is. I can add a runtime `uname` usage if you like. On my 6.8.0-41 for example, `/usr/include/linux/version.h` contains `#define LINUX_VERSION_CODE 395276`. In Alpine in Docker with 6.6-r0 of linux-headers `apk` on that same base, I get `#define LINUX_VERSION_CODE 394752`. Pretty sure this version restriction in the PR is sufficient, but keep this comment in mind; happy to change the version.