### PR TITLE
amdgpu: validate pointer before access its field in amdgpu_gem_object…

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
@@ -98,7 +98,7 @@ static void amdgpu_gem_object_free(struct drm_gem_object *gobj)
 #endif
 {
 	struct amdgpu_bo *robj = gem_to_amdgpu_bo(gobj);
-	struct amdgpu_device *adev = amdgpu_ttm_adev(robj->tbo.bdev);
+	struct amdgpu_device *adev;
 
 	if (robj) {
 		if (robj->flags & AMDGPU_GEM_CREATE_NO_EVICT) {
@@ -108,6 +108,7 @@ static void amdgpu_gem_object_free(struct drm_gem_object *gobj)
 			}
 		}
 
+		adev = amdgpu_ttm_adev(robj->tbo.bdev);
 		if (robj->tbo.resource && robj->tbo.resource->mem_type == AMDGPU_PL_DGMA)
 			atomic64_sub(amdgpu_bo_size(robj),
 				     &adev->direct_gma.vram_usage);


### PR DESCRIPTION
Validate pointer before access its field in amdgpu_gem_object_free(), to avoid invalid memory access.