### PR TITLE
Better support suspend/resume with AMDGPU on bare metal server

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/soc15.c
+++ b/drivers/gpu/drm/amd/amdgpu/soc15.c
@@ -583,11 +583,9 @@ static bool soc15_need_reset_on_resume(struct amdgpu_device *adev)
 	sol_reg = RREG32_SOC15(MP0, 0, mmMP0_SMN_C2PMSG_81);
 
 	/* Will reset for the following suspend abort cases.
-	 * 1) Only reset limit on APU side, dGPU hasn't checked yet.
-	 * 2) S3 suspend abort and TOS already launched.
+	 * 1) S3 suspend abort and TOS already launched.
 	 */
-	if (adev->flags & AMD_IS_APU && adev->in_s3 &&
-			sol_reg) {
+	if (adev->in_s3 && sol_reg) {
 		adev->suspend_complete = false;
 		return true;
 	} else {

--- a/drivers/gpu/drm/amd/amdgpu/soc21.c
+++ b/drivers/gpu/drm/amd/amdgpu/soc21.c
@@ -903,13 +903,14 @@ static bool soc21_need_reset_on_resume(struct amdgpu_device *adev)
 	 * 1) Only reset dGPU side.
 	 * 2) S3 suspend got aborted and TOS is active.
 	 */
-	if (!(adev->flags & AMD_IS_APU) && adev->in_s3 &&
-	    !adev->suspend_complete) {
+	if (!(adev->flags & AMD_IS_APU) && adev->in_s3) {
 		sol_reg1 = RREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_81);
 		msleep(100);
 		sol_reg2 = RREG32_SOC15(MP0, 0, regMP0_SMN_C2PMSG_81);
-
-		return (sol_reg1 != sol_reg2);
+		if (sol_reg1 != sol_reg2) {
+			adev->suspend_complete = false;
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
When testing suspend/resume with AMDGPU device on bare metal servers, it fails to resume on the third time. Fix the issue by resetting the ASIC when needed.