### PR TITLE
Unset TMPDIR as to Avoid Conflict with libpam-tmpdir Package

### DIFF
--- a/drivers/gpu/drm/amd/dkms/pre-build.sh
+++ b/drivers/gpu/drm/amd/dkms/pre-build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# unset TMPDIR in this shell
+# otherwise conflicting package libpam-tmpdir incorrectly generates config
+unset TMPDIR
+
 KCL="amd/amdkcl"
 INC="include"
 SRC="amd/dkms"


### PR DESCRIPTION
This PR addresses ROCm issue 4204 (https://github.com/ROCm/ROCm/issues/4204)
> Following a deep dive into amdgpu-dkms, it seems there is a incompatibility (bug?) in DKMS module's amd/dkms/configure script, which (when libpam-tmpdir is active) generates an incorrect amd/dkms/config/config.h file that won't compile.
> 
> In particular, when the configure script runs test compilations, it creates a temporary build directory a la:
> 
> build_dir=$(mktemp -d -t build_XXXXXXXX -p $build_dir_root)
> .. where $build_dir_root is /var/lib/dkms/amdgpu/6.10.5-2095006.24.04/build (or similar, depending on your system).
> 
> The problem is that, according to mktemp --help, the presence of the -d switch in the call to mktemp means that the -p $build_dir_root argument is ignored in favor of the TMPDIR environment variable, if it exists. Setting TMPDIR, meanwhile, is the entire purpose of the libpam-tmpdir pam module.
> 
> In some test compilations, however, the ./configure script adds -I../tiny_wrapper/include to CFLAGS, meaning correct results are contingent on $build_dir being a subdirectory of $build_dir_root.
> 
> False negatives in these test compilations lead to several macros not being defined in config.h, which causes the inclusion of code that won't compile, leading to the errors seen in https://github.com/ROCm/ROCm/issues/4164.

Steps to reproduce:
Install `libpam-tmpdir` package
Run `sudo pam-auth-update` and enable "per-user temp directories" (if not already enabled)
Log out, or reboot to ensure the `TMPDIR` env var is set.
Follow instructions at https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html

Credit for find: @mvastola